### PR TITLE
dev

### DIFF
--- a/.changeset/hip-peaches-tease.md
+++ b/.changeset/hip-peaches-tease.md
@@ -1,0 +1,5 @@
+---
+"@elucidario/app-site": patch
+---
+
+change the newsletter add lead call to firebase cloud function @elucidario/lead

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -1,10 +1,7 @@
 name: Deploy site
 
 on:
-  workflow_run:
-    workflows: ["version"]
-    types:
-      - completed
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -25,9 +22,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Env
-        run: echo "VITE_BREVO_TOKEN=${{ secrets.VITE_BREVO_TOKEN }}" >> $GITHUB_ENV
 
       - name: Build
         run: pnpm build:site

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -37,15 +37,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: save
-        run: |
-          echo "pr_number=${{ steps.changeset.outputs.pullRequestNumber }}" > release.txt
-          echo "has_changeset=${{ steps.changeset.outputs.hasChangesets }}" >> release.txt
-          echo "published=${{ steps.changeset.outputs.published }}" >> release.txt
-          echo "published_packages=${{ steps.changeset.outputs.publishedPackages }}" >> release.txt
-
-      - name: artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: changeset
-          path: release.txt
+      - name: deploy
+        if: steps.changeset.outputs.hasChangesets == 'false'
+        uses: ./.github/workflows/deploy-site.yaml@main

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "MD013": false,
+    "MD033": {
+        "allowed_elements": ["h1", "picture", "source", "img"]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,44 +1,83 @@
+<h1>
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/hgodinho/elucidario/main/packages/design-system/assets/svg/type%3Dvertical%2C%20color%3Dpink%2C%20theme%3Ddark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/hgodinho/elucidario/main/packages/design-system/assets/svg/type%3Dvertical%2C%20color%3Dpink%2C%20theme%3Dlight.svg">
-    <img src="https://raw.githubusercontent.com/hgodinho/elucidario/main/packages/design-system/assets/svg/type%3Dvertical%2C%20color%3Dpink%2C%20theme%3Ddark.svg" alt="Logo Elucidário.art" width="300" style="margin-bottom: 16px">
+<source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/elucidario/elucidario.art/refs/heads/main/apps/site/public/svg/type%3Dvertical-color%3Dprimary-theme%3Ddark.svg">
+<source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/elucidario/elucidario.art/refs/heads/main/apps/site/public/svg/type%3Dvertical-color%3Dprimary-theme%3Dlight.svg">
+<img src="https://raw.githubusercontent.com/elucidario/elucidario.art/refs/heads/main/apps/site/public/svg/type%3Dvertical-color%3Dprimary-theme%3Ddark.svg" alt="Logo elucidario.art" width="296" style="margin-bottom: 16px">
 </picture>
+</h1>
 
-> Sistema de Gestão de Coleções para museus, galerias, acervos e coleções de arte.
+Sistema de Gestão de Coleções para museus, galerias, acervos e coleções de arte.
 
-![monorepo](https://img.shields.io/badge/monorepo-%230078c8?style=flat-square) ![elucidário.art](https://img.shields.io/website?url=https%3A%2F%2Felucidario.art&up_color=%2346C23A&down_color=%23FD7671&style=flat-square&label=elucidario.art&labelColor=011C3E) ![GitHub last commit](https://img.shields.io/github/last-commit/hgodinho/elucidario?style=flat-square&labelColor=501028&color=e82070)
+![monorepo](https://img.shields.io/badge/monorepo-%230078c8?style=flat-square) ![elucidário.art](https://img.shields.io/website?url=https%3A%2F%2Felucidario.art&up_color=%2346C23A&down_color=%23FD7671&style=flat-square&label=elucidario.art&labelColor=011C3E) ![GitHub last commit](https://img.shields.io/github/last-commit/elucidario/elucidario.art?style=flat-square&labelColor=501028&color=e82070)
 
-Em linhas gerais o Elucidário.art é um _Collection Management System_. A abreviação CMS é majoritariamente conhecida com um outro significado: _Content Management System_, devido a popularidade de plataformas como WordPress, Joomla, Drupal, etc. O Elucidário.art é um CMS para coleções de arte, ou seja, é um sistema de gerenciamento de coleções de arte, ou um _Content Management System_ especializado. Portanto utilizaremos a abreviação CMS para nos referirmos ao Elucidário como um _Collection Management System_. Este termo também é utilizado por instituições como [_Collections Trust_](collectionstrust.org.uk/) e [ICOM](https://icom.museum/) para referir-se a esta modalidade de software.
+## descrição
 
-Em suma, o Elucidário.art consiste em um plugin para WordPress que define um conjunto de funcionalidades para gerenciamento de coleções de arte. O plugin utiliza o modelo de dados para aplicações [Linked Art](https://linked.art) para definição das classes principais de conteúdo e se baseia nos procedimentos [Spectrum](https://collectionstrust.org.uk/spectrum/) para definição de seus fluxos de trabalho.
+Em linhas gerais o ***elucidario.art*** é um *Collection Management System*.
+A abreviação CMS é majoritariamente conhecida com um outro significado: *Content Management System*, devido a popularidade de plataformas como WordPress, Joomla, Drupal, etc. O ***elucidario.art*** é um CMS para coleções de arte, ou seja, é um sistema de gerenciamento de coleções de arte, ou um *Content Management System* especializado. Portanto utilizaremos a abreviação CMS para nos referirmos ao Elucidário como um *Collection Management System*. Este termo também é utilizado por instituições como [*Collections Trust*](collectionstrust.org.uk/) e [ICOM](https://icom.museum/) para referir-se a esta modalidade de software.
+
+Em suma, o ***elucidario.art*** é um conjunto de funcionalidades para gerenciamento de coleções de arte que utiliza o modelo de dados para aplicações [Linked Art](https://linked.art) para definição das classes principais de conteúdo e se baseia nos procedimentos [Spectrum](https://collectionstrust.org.uk/spectrum/) para definição de seus fluxos de trabalho.
+
+## desenvolvimento
+
+### containers
+
+Para rodar o ambiente de desenvolvimento do ***elucidario.art***, é necessário ter o [Docker](https://www.docker.com/) instalado. Então, basta rodar o seguinte comando na raiz do projeto:
+
+```bash
+docker compose up --build
+```
+
+Para rodar os componentes isolados, é necessário passar o nome do serviço como argumento para o comando acima:
+
+```bash
+docker compose up --build <nome-serviço>
+```
+
+Por exemplo, para rodar apenas o site:
+
+```bash
+docker compose up --build dev_site
+```
+
+Para ver os serviços disponíveis consulte o arquivo [`compose.yaml`](./compose.yaml).
+
+### repositório
 
 O repositório está estruturado em uma arquitetura de mono-repositório, em que os pacotes são distribuídos em subdiretórios na raíz do projeto. Cada pacote é uma funcionalidade, ou micro-serviço, que pode ser utilizado de forma independente. A estrutura de diretórios é a seguinte:
 
 ```bash
 elucidario
+├── core
 ├── apps
 ├── packages
-├── publications
-├── references
 ├── tools
-├── types
 ├── ...
 ```
 
+O diretório `core` contém o pacote principal do ***elucidario.art***, consiste no núcleo do sistema, onde estão definidos os modelos de dados, as regras de negócio e os fluxos de trabalho. O pacote `@elucidario/core` é o coração do sistema.
+
 O diretório `packages` contém os pacotes que podem ser reutilizados, tanto por outros pacotes, como por aplicações. Todos os pacotes definidos nesta pasta seguem o padrão de nome `@elucidario/pkg-<nome-pacote>`.
 
-No diretório `apps`, se encontram as aplicações, como um ambiente de desenvolvimento completo utilizando Docker para testes locais e o site do Elucidário.art disponível em <http://elucidario.art/>. Os pacotes nesta pasta seguem o padrão de nome `@elucidario/app-<nome-pacote>`.
+No diretório `apps`, se encontram as aplicações, como um ambiente de desenvolvimento completo utilizando Docker para testes locais e o site do ***elucidario.art*** disponível em <https://elucidario.art/>. Os pacotes nesta pasta seguem o padrão de nome `@elucidario/app-<nome-pacote>`.
 
-O diretório `publications` contém as publicações referentes ao Elucidário.art, como a dissertação de mestrado e outros artigos desenvolvidos ao longo da pesquisa. Os pacotes nesta pasta seguem o padrão de nome `@elucidario/pub-<nome-pacote>`.
+Em `tools` estão os scripts e ferramentas auxiliares para o desenvolvimento do ***elucidario.art***. Os pacotes nesta pasta seguem o padrão de nome `@elucidario/tool-<nome-pacote>`.
 
-No diretório `references` contém referências utilizadas no desenvolvimento de todo o ecossistema do Elucidário.art e estão organizadas em um arquivo JSON para cada referência seguindo o formato [_Citation Style Language_ (CSL)](https://github.com/citation-style-language) (D’Arcus, 2010).
+Todos os pacotes nos diretórios `apps` e `packages`, e o `core` devem ser construídos levando em conta as seguintes boas práticas de design, ou técnicas de programação, quando aplicáveis:
 
-Em `tools` estão os scripts e ferramentas auxiliares para o desenvolvimento do Elucidário.art. Os pacotes nesta pasta seguem o padrão de nome `@elucidario/tool-<nome-pacote>`.
+- **a11y (*accessibility*)** - quando aplicável o pacote deve seguir as regras de acessibilidade apropriadas para o contexto;
+- **i10n (*localization*)** - quando aplicável o pacote deve implementar o suporte a localização dos idiomas português, espanhol e inglês, seguindo esta ordem de prioridade;
+- **i18n (*internationalization*)** - quando aplicável o pacote deve implementar o suporte a internacionalização, e o processo de localização deve ser devidamente documentado;
 
-O diretório `types` contém os tipos Typescript utilizados em todo o ecossistema do Elucidário.art. Os pacotes nesta pasta seguem o padrão de nome `@elucidario/types-<nome-pacote>`.
+## CI
 
-Todos os pacotes nos diretórios `apps` e `packages` foram construídos levando em conta os seguintes princípios de design, ou técnicas de programação:
+### [`changeset-check.yaml`](./.github/workflows/changeset-check.yaml)
 
-- a11y (_accessibility_) - quando aplicável o pacote deve seguir as regras de acessibilidade apropriadas para o contexto;
-- i10n (_localization_) - quando aplicável o pacote deve implementar o suporte a localização dos idiomas português, espanhol e inglês, seguindo esta ordem de prioridade;
-- i18n (_internationalization_) - quando aplicável o pacote deve implementar o suporte a internacionalização, e o processo de localização deve ser devidamente documentado;
+Verifica se a PR possui um arquivo [`changeset`](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) e se o mesmo foi modificado.
+
+### [`version.yaml`](./.github/workflows/version.yaml)
+
+Incrementa a versão dos pacotes modificados.
+
+### [`deploy-site.yaml`](./.github/workflows/deploy-site.yaml)
+
+Faz o deploy do site do ***elucidario.art***.

--- a/apps/site/.env.example
+++ b/apps/site/.env.example
@@ -1,1 +1,1 @@
-VITE_BREVO_TOKEN=your_brevo_token
+VITE_LEAD_URL=<your-lead-url>

--- a/apps/site/.gitignore
+++ b/apps/site/.gitignore
@@ -1,0 +1,2 @@
+.env.development
+.env.production

--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -1,37 +1,27 @@
-This app has been created with [Bati](https://batijs.dev) using the following flags: `--react --tailwindcss --eslint`
+# `@elucidario/app-site`
 
-# About this app
+> Site for elucidario.art
 
-This app is ready to start. It's powered by [Vike](https://vike.dev) and [React](https://react.dev/learn).
+This site is create with [vike](https://vike.dev).
 
-### `/pages/+config.ts`
+## Development
 
-Such `+` files are [the interface](https://vike.dev/config) between Vike and your code. It defines:
+Prefer docker container at `root`, see [README.md](../../README.md).
 
-- A default [`<Layout>` component](https://vike.dev/Layout) (that wraps your [`<Page>` components](https://vike.dev/Page)).
-- A default [`title`](https://vike.dev/head).
-- Default [`<head>` tags](https://vike.dev/head).
+Else:
 
-### Routing
+1. Setup environment variables
 
-[Vike's built-in router](https://vike.dev/routing) lets you choose between:
+    ```bash
+    pnpm env:setup
+    ```
 
-- [Filesystem Routing](https://vike.dev/filesystem-routing) (the URL of a page is determined based on where its `+Page.jsx` file is located on the filesystem)
-- [Route Strings](https://vike.dev/route-string)
-- [Route Functions](https://vike.dev/route-function)
+2. Run development command
 
-### `/pages/_error/+Page.jsx`
+    ```bash
+    pnpm dev
+    ```
 
-The [error page](https://vike.dev/error-page) which is rendered when errors occur.
+## Deployment
 
-### `/pages/+onPageTransitionStart.ts` and `/pages/+onPageTransitionEnd.ts`
-
-The [`onPageTransitionStart()` hook](https://vike.dev/onPageTransitionStart), together with [`onPageTransitionEnd()`](https://vike.dev/onPageTransitionEnd), enables you to implement page transition animations.
-
-### SSR
-
-SSR is enabled by default. You can [disable it](https://vike.dev/ssr) for all your pages or only for some pages.
-
-### HTML Streaming
-
-You can enable/disable [HTML streaming](https://vike.dev/streaming) for all your pages, or only for some pages while still using it for others.
+The deployment is CI, see [`.github/workflows/deploy-site.yaml`](../../.github/workflows/deploy-site.yaml).

--- a/apps/site/bin/setup-environment.sh
+++ b/apps/site/bin/setup-environment.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Ask user for URLs
+read -p "Type dev lead URL: " DEV_URL
+read -p "Type prod lead URL: " PROD_URL
+
+# Create files
+echo "VITE_LEAD_URL=$DEV_URL" > .env.development
+echo "VITE_LEAD_URL=$PROD_URL" > .env.production
+
+# Inform user
+echo "Environment setup complete!"

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -7,6 +7,7 @@
     "author": "Henrique Godinho <ola@hgod.in>",
     "type": "module",
     "scripts": {
+        "env:setup": "bin/setup-environment.sh",
         "build": "vike build",
         "dev": "vite",
         "lint": "eslint 'src/**' --fix",

--- a/apps/site/src/components/newsletter/Newsletter.tsx
+++ b/apps/site/src/components/newsletter/Newsletter.tsx
@@ -33,23 +33,18 @@ export function Newsletter<T extends Record<string, unknown>>({
 
         const options = {
             method: "POST",
-            url: "https://api.brevo.com/v3/contacts/doubleOptinConfirmation",
+            url: `${import.meta.env.VITE_LEAD_URL}/leads`,
             headers: {
                 accept: "application/json",
                 "Content-Type": "application/json",
-                "api-key": import.meta.env.VITE_BREVO_TOKEN,
             },
             data: {
-                attributes: {
-                    NOME: data.name,
-                    JOB_TITLE: data.role,
-                    ORGANIZATION: data.organization,
+                user: data,
+                options: {
+                    listIds: includeListIds,
+                    templateId,
+                    redirectionUrl: redirUrl,
                 },
-                email: data.email,
-
-                includeListIds,
-                templateId,
-                redirectionUrl: redirUrl,
             },
         };
 


### PR DESCRIPTION
This PR introduce changes in CI, lint, docs and @elucidario/app-site package

- **ci(workflow): make deploy reusable and call it at version**
- **chore(markdownlint): add markdownlint**
- **docs(readme): update readmes**
- **feat(site): setup environment**
- **fix(site): newsletter now uses @elucidario/lead firebase cloud function**
- **chore(changeset): add**
